### PR TITLE
Exiting with 1 on execution error

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ use sbtclient::print::{Printer, print_log};
 use sbtclient::receive::HeaderParser;
 
 use std::env;
+use std::process;
 
 fn main() {
     let args: Vec<String> = env::args().skip(1).collect();
@@ -24,10 +25,13 @@ fn main() {
     } else {
         let sbt_command_line = args.join(" ");
 
-        match run(sbt_command_line) {
-            Ok(_) => (), // yay
-            Err(e) => print_log(1, e.message)
-        }
+        process::exit(match run(sbt_command_line) {
+            Ok(_) => 0, // yay
+            Err(e) => {
+                print_log(1, e.message);
+                1
+            }
+        })
     }
 }
 

--- a/src/sbtclient/receive.rs
+++ b/src/sbtclient/receive.rs
@@ -51,11 +51,11 @@ pub fn receive_next_message<S: Read, H: MessageHandler>(stream: &mut S,
         .map_err(|e| detailed_error("Failed to decode message as UTF-8 string", e))?;
     let message: Message = serde_json::from_str(&raw_json)
         .map_err(|e| detailed_error(&format!("Failed to deserialize message from JSON '{}'", raw_json), e))?;
-    let received_result = match message {
-        SuccessResponse { id, .. } if id == 1 => true,
-        ErrorResponse { id, .. } if id == 1 => true,
-        _ => false
-    };
+    let received_result = (match message {
+        SuccessResponse { id, .. } if id == 1 => Ok(true),
+        ErrorResponse { id, .. } if id == 1 => Err(error("Error from sbt")),
+        _ => Ok(false)
+    })?;
     handler.handle(message);
     Ok(received_result)
 }


### PR DESCRIPTION
I've got a significantly large PR that I'm trying to perform surgery on using `git rebase -i`. While I can intersperse the following:
```
exec sbt-client test:compile
```
... between each `pick` in the rebase todo, `sbt-client` only ever returns success, so I can't do more logic based on whether the command succeeded or failed (in this case, interrupting the rebase).

I didn't have a good error message to raise to `main`, but this solves the problem I've got right now.

Thanks for writing this!